### PR TITLE
DPI-2931 Package rhtmlLabeledScatter in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -6,7 +6,7 @@ pkgs.rPackages.buildRPackage {
   src = ./.;
   description = ''An HTML widget that creates a labeled scatter plot.'';
   propagatedBuildInputs = with pkgs.rPackages; [ 
-    jsonlite
     htmlwidgets
+    jsonlite
   ];
 }


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package rhtmlLabeledScatter in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR